### PR TITLE
[Feature]: add support to use options on translate call and error handling

### DIFF
--- a/lib/deepl.ex
+++ b/lib/deepl.ex
@@ -5,15 +5,19 @@ defmodule DeeplEx.DeepL do
   def translate(client, %{
         source_language: source_language,
         target_language: target_language,
-        text: text
+        text: text,
+        options: options
       }) do
-    Tesla.post(client, "/translate", %{
-      text: [
-        text
-      ],
-      source_lang: parse_language(source_language),
-      target_lang: parse_language(target_language)
-    })
+    content =
+      Map.merge(options, %{
+        text: [
+          text
+        ],
+        source_lang: parse_language(source_language),
+        target_lang: parse_language(target_language)
+      })
+
+    Tesla.post(client, "/translate", content)
   end
 
   def client(api_key, tier) do

--- a/lib/helpers/options_validator.ex
+++ b/lib/helpers/options_validator.ex
@@ -1,0 +1,37 @@
+defmodule DeeplEx.OptionsValidator do
+  @moduledoc """
+  This module is responsible for validating the options for translate that are supplied.
+  """
+
+  @valid_options [
+    :split_sentences,
+    :preserve_formatting,
+    :formality,
+    :glossary_id,
+    :tag_handling,
+    :outline_detection,
+    :non_splitting_tags,
+    :splitting_tags,
+    :ignore_tags
+  ]
+
+  @doc false
+  def valid_options?(options) when is_map(options) do
+    options_keys = Map.keys(options)
+
+    case options_keys -- @valid_options do
+      [] -> {:valid_options?, true}
+      _ -> {:valid_options?, false}
+    end
+
+    {:valid_options?, true}
+  end
+
+  @doc false
+  def valid_options?(_), do: {:valid_options?, false}
+
+  @doc """
+  Returns a list containing the valid options for translate
+  """
+  def valid_options, do: @valid_options
+end

--- a/lib/helpers/options_validator.ex
+++ b/lib/helpers/options_validator.ex
@@ -23,8 +23,6 @@ defmodule DeeplEx.OptionsValidator do
       [] -> {:valid_options?, true}
       _ -> {:valid_options?, false}
     end
-
-    {:valid_options?, true}
   end
 
   @doc false


### PR DESCRIPTION
# Description

Adds support to use options on translate calls and error handling

## Type of change

<!-- Please check options that are relevant and strikethrough or remove options that are not relevant: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Examples

```
iex> DeeplEx.translate("Hello man, how are you??", :EN, :PT_BR, %{formality: "less"})
{:ok, "Olá, cara, como você está?"}
iex> DeeplEx.translate("Hello man, how are you??", :EN, :PT_BR, %{formality: "more"})
{:ok, "Olá, senhor, como o senhor está?"}
iex> DeeplEx.translate("Hello man, how are you??", :EN, :PT_BR, %{formality: "invalid"})
{:error, "Invalid request: Value for 'formality' not supported."}
```


